### PR TITLE
Add desktop share button to header navigation

### DIFF
--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -61,6 +61,26 @@ export default function Header()
       setSearch("")
     }
   }
+ 
+const handleShare = async () => {
+  const shareData = {
+    title: "CUBOSAPIENS",
+    text: "Free tools, games & AI — no signup needed!",
+    url: "https://cubosapiens.world",
+  }
+
+  try {
+    if (navigator.share) {
+      await navigator.share(shareData)
+    } else {
+      await navigator.clipboard.writeText(shareData.url)
+      alert("Link copied to clipboard!")
+    }
+  } catch (error) {
+    console.error("Share failed:", error)
+  }
+}
+
 
   return (
     <>
@@ -98,6 +118,13 @@ export default function Header()
                 {link.label}
               </Link>
             ))}
+            <button
+  className="header-nav-link"
+  onClick={handleShare}
+  aria-label="Share website"
+>
+  <i className="fa-solid fa-share-nodes"></i>
+</button>
           </nav>
 
           {/* ── RIGHT SIDE ── */}
@@ -205,13 +232,9 @@ export default function Header()
               <p className="dropdown-promo-desc">Free tools & games for everyone — share with friends!</p>
               <button
                 className="dropdown-promo-btn"
-                onClick={() => {
-                  navigator.share?.({
-                    title: "CUBOSAPIENS",
-                    text:  "Free tools, games & AI — no signup needed!",
-                    url:   "https://cubosapiens.world",
-                  }) ?? navigator.clipboard.writeText("https://cubosapiens.world")
-                }}
+                onClick={handleShare}
+                
+              
               >
                 Share Link
               </button>


### PR DESCRIPTION
Description

Added a desktop share button to the header navigation for consistent sharing functionality across desktop and mobile experiences.

Changes Made

* Added Font Awesome share icon button to desktop navbar
* Reused existing mobile share functionality using a shared `handleShare` function
* Added clipboard fallback for unsupported browsers
* Added user feedback when link is copied
* Included accessibility support using `aria-label`

Testing

* Verified desktop share button visibility
* Tested clipboard fallback functionality locally
* Confirmed no layout issues in the header

Closes #10 
