### PR TITLE
fix(ui): prevent body scroll when mobile menu is open

### DIFF
--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -52,6 +52,18 @@ export default function Header()
   useEffect(() => {
     if(searchOpen) searchRef.current?.focus()
   }, [searchOpen])
+
+  useEffect(() => {
+    if (menuOpen) {
+      document.body.style.overflow = "hidden"
+    } else {
+      document.body.style.overflow = ""
+    }
+    return () => {
+      document.body.style.overflow = ""
+    }
+  }, [menuOpen])
+
 function handleSearch(e: React.FormEvent) {
   e.preventDefault()
   if(search.trim()) {


### PR DESCRIPTION
This PR fixes the background scrolling issue on mobile devices. I implemented a useEffect hook to apply overflow: hidden to the body when menuOpen is true, and clean it up when closed