### PR TITLE
fix(ui): prevent body scroll when mobile menu is open

### DIFF
--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -55,6 +55,18 @@ export default function Header() {
   useEffect(() => {
     if (searchOpen) searchRef.current?.focus()
   }, [searchOpen])
+
+  useEffect(() => {
+    if (menuOpen) {
+      document.body.style.overflow = "hidden"
+    } else {
+      document.body.style.overflow = ""
+    }
+    return () => {
+      document.body.style.overflow = ""
+    }
+  }, [menuOpen])
+
   function handleSearch(e: React.FormEvent) {
     e.preventDefault()
     if (search.trim()) {


### PR DESCRIPTION
Hi @rk192324217,

As requested, I am re-raising this PR targeted at the dev branch.

What this does: Implemented a useEffect hook to apply overflow: hidden to the body when the mobile menu is open, preventing background content from scrolling.

Linked Issue: Fixes #6 

Verification: Below is a screen recording proving the background is locked when the menu is open:

https://github.com/user-attachments/assets/e9a06cc2-2274-4803-9541-4a7a59da3306

