### PR TITLE
include games in search results

### DIFF
--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -1,4 +1,4 @@
-import { fetchTools }   from "@/lib/api"
+import { fetchTools, fetchGames } from "@/lib/api"
 import SearchResults    from "@/components/ui/SearchResults"
 
 interface Props {
@@ -8,17 +8,27 @@ interface Props {
 export default async function SearchPage({ searchParams }: Props)
 {
   const { q }  = await searchParams
-  const tools  = await fetchTools()
+  
+  // Fetch both concurrently to improve load times
+  const [tools, games] = await Promise.all([
+    fetchTools(),
+    fetchGames()
+  ])
 
   return (
     <div className="page-container">
       <div className="page-hero">
         <span className="section-tag">Search</span>
         <h1 className="page-hero-title">
-          {q ? `Results for "${q}"` : "Search Tools"}
+          {q ? `Results for "${q}"` : "Search Everything"}
         </h1>
       </div>
-      <SearchResults tools={tools} initialQuery={q || ""} />
+      <SearchResults tools={tools} games={games} initialQuery={q || ""} />
     </div>
   )
 }
+
+
+
+
+

--- a/apps/web/src/components/ui/SearchResults.tsx
+++ b/apps/web/src/components/ui/SearchResults.tsx
@@ -2,7 +2,8 @@
 
 import { useState }  from "react"
 import ToolCard      from "@/components/ui/ToolCard"
-import type { Tool } from "@/types"
+import GameCard      from "@/components/ui/GameCard" 
+import type { Tool, Games } from "@/types"
 
 const categories = [
   { key: "all",       label: "All"       },
@@ -11,42 +12,54 @@ const categories = [
   { key: "generator", label: "⚡ Generator" },
   { key: "text",      label: "✏️ Text"   },
   { key: "converter", label: "🔄 Converter" },
+  { key: "game",      label: "🎮 Games"   }, 
 ]
 
 interface Props {
   tools:        Tool[]
+  games:        Games[] 
   initialQuery: string
 }
 
-export default function SearchResults({ tools, initialQuery }: Props)
+// Our unified type for the search array
+type SearchItem = 
+  | (Tool & { itemType: "tool"; unifiedCategory: string })
+  | (Games & { itemType: "game"; unifiedCategory: string })
+
+export default function SearchResults({ tools, games, initialQuery }: Props)
 {
   const [query,  setQuery]  = useState(initialQuery)
   const [active, setActive] = useState("all")
 
-  const results = tools.filter(t => {
-    const matchCat    = active === "all" || t.category === active
+  const allItems: SearchItem[] = [
+    ...tools.map((t): SearchItem => ({ ...t, itemType: "tool", unifiedCategory: t.category })),
+    ...games.map((g): SearchItem => ({ ...g, itemType: "game", unifiedCategory: g.genre || "game" }))
+  ]
+
+  const results = allItems.filter(item => {
+    const matchCat    = active === "all" || item.unifiedCategory === active
     const q           = query.toLowerCase()
+    
     const matchSearch = !q ||
-      t.name.toLowerCase().includes(q) ||
-      t.description.toLowerCase().includes(q) ||
-      t.category.toLowerCase().includes(q)
+      item.name.toLowerCase().includes(q) ||
+      item.description.toLowerCase().includes(q) ||
+      item.unifiedCategory.toLowerCase().includes(q)
+      
     return matchCat && matchSearch
   })
 
   return (
     <>
-      {/* Search input */}
       <div className="tools-search-wrap">
         <input
           className="tools-search"
-          placeholder="Search tools..."
+          placeholder="Search tools and games..."
           value={query}
           onChange={e => setQuery(e.target.value)}
           autoFocus
         />
       </div>
 
-      {/* Filters */}
       <div className="filter-tabs">
         {categories.map(cat => (
           <button
@@ -59,22 +72,27 @@ export default function SearchResults({ tools, initialQuery }: Props)
         ))}
       </div>
 
-      {/* Count */}
       <p className="tools-count">
         {results.length} result{results.length !== 1 ? "s" : ""}
       </p>
 
-      {/* Grid */}
       {results.length > 0 ? (
         <div className="tool-grid">
-          {results.map((tool, i) => (
-            <ToolCard key={tool.id} tool={tool} index={i} />
-          ))}
+          {results.map((item, i) => {
+            // By explicitly casting `as Tool` and `as Games`, 
+            // we stop TypeScript from complaining about the extra properties 
+            // we added during the merge.
+            if (item.itemType === "tool") {
+              return <ToolCard key={`tool-${item.id}`} tool={item as Tool} index={i} />
+            } else {
+              return <GameCard key={`game-${item.id}`} game={item as Games} index={i} />
+            }
+          })}
         </div>
       ) : (
         <div className="empty-state">
           <p>No results found</p>
-          <span>Try different keywords or browse all tools</span>
+          <span>Try different keywords or browse all categories</span>
         </div>
       )}
     </>


### PR DESCRIPTION
This PR fixes the issue where games were not appearing in the search results. Previously, search/page.tsx only fetched the tools array, meaning queries for existing games returned no results.

Changes Made

apps/web/src/app/search/page.tsx: Updated to fetch both tools and games concurrently using Promise.all() and passed the games data to the SearchResults component.

apps/web/src/components/ui/SearchResults.tsx:

Merged the tools and games arrays into a unified SearchItem type to ensure type safety.

Added a "🎮 Games" category to the filter tabs.

Updated the filtering logic to search across both arrays using a normalized category/genre field.

Conditionally rendered or based on the item type.

Related Issue
Fixes #37 

Checklist

[x] Tested search functionality locally with keywords like "snake" and "chess".

[x] Verified category filtering works for both tools and games.

[x] Ensured there are no TypeScript compilation errors.
before the fix 👎
<img width="1560" height="767" alt="595009123-1ae50c16-9bd0-4390-8b92-d3b72c93c2e5" src="https://github.com/user-attachments/assets/08ce7332-1841-4e9d-b93c-a1a54aa0cfe6" />

after fix: 
<img width="1376" height="809" alt="595008613-ceb7be08-4afb-431d-9ff6-fd7a0c034837" src="https://github.com/user-attachments/assets/bbc0e556-6559-4ed7-9aba-279f3c459cdd" />


fixes https://github.com/rk192324217/cubosapiens_world-tools/issues/37