### PR TITLE
fix(ui): update menu to fixed positioning to prevent freezing

### DIFF
--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -59,11 +59,14 @@ export default function Header() {
   useEffect(() => {
     if (menuOpen) {
       document.body.style.overflow = "hidden"
+      document.documentElement.style.overflow = "hidden"
     } else {
       document.body.style.overflow = ""
+      document.documentElement.style.overflow = ""
     }
     return () => {
       document.body.style.overflow = ""
+      document.documentElement.style.overflow = ""
     }
   }, [menuOpen])
 
@@ -198,7 +201,7 @@ export default function Header() {
 
         {/* ── MOBILE DROPDOWN MENU ── */}
         {menuOpen && ( // added an additional functionality so that the X works and the menu is closeable in phone.
-          <div className="header-dropdown" ref={menuRef}>
+          <div className="header-dropdown fixed left-0 right-0 top-[70px] overflow-y-auto max-h-[calc(100vh-70px)] overscroll-contain z-50 bg-[#0a0a0a]/95 backdrop-blur-md" ref={menuRef}>
             <button
               className="dropdown-promo-btn"
               onClick={handleShare}


### PR DESCRIPTION
Hi @rk192324217,

Here is the updated PR targeting the dev branch as requested.

Updates made: > * Locked both document.body and document.documentElement to prevent background rubber-banding on mobile touch events.

Applied fixed positioning and overflow-y-auto to the menu container so it appears correctly even if the user has scrolled down the page, and allows natural scrolling within the menu itself.

Linked Issue: Fixes #6 

Verification: Below is a screen recording proving the menu stays on-screen and scrolls naturally while the background remains completely frozen:

https://github.com/user-attachments/assets/c761264c-1d51-433c-9283-c9aac2acf39d

