### PR TITLE
Added GitHub star counter and redirect button 

### DIFF
--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -25,6 +25,7 @@ const moreLinks = [
 export default function Header({ hasLiveAi }: { hasLiveAi: boolean }) {
   const [visitors, setVisitors] = useState<number | null>(null)
   const [search, setSearch] = useState("")
+  const [stars, setStars] = useState<number | null>(null)
   const [menuOpen, setMenuOpen] = useState(false)
   const [searchOpen, setSearchOpen] = useState(false)
   const pathname = usePathname()
@@ -68,6 +69,13 @@ export default function Header({ hasLiveAi }: { hasLiveAi: boolean }) {
       document.body.style.overflow = ""
     }
   }, [menuOpen])
+
+  useEffect(() => {
+  fetch("https://api.github.com/repos/rk192324217/cubosapiens_world-tools")
+    .then(res => res.json())
+    .then(data => setStars(data.stargazers_count))
+    .catch(() => setStars(null))
+}, [])
 
   function handleSearch(e: React.FormEvent) {
     e.preventDefault()
@@ -154,6 +162,15 @@ export default function Header({ hasLiveAi }: { hasLiveAi: boolean }) {
 
           {/* ── RIGHT SIDE ── */}
           <div className="header-right flex items-center gap-3">
+            <a
+           href="https://github.com/rk192324217/cubosapiens_world-tools"
+           target="_blank"
+           rel="noopener noreferrer"
+           className="flex items-center gap-1 px-2 py-1 rounded bg-black/40 hover:bg-black/60 text-white text-sm"
+           >
+           <i className="fa-solid fa-star text-yellow-400"></i>
+           <span>{stars !== null ? stars : "..."}</span>
+           </a>
 
             {/* Desktop search bar */}
             <form onSubmit={handleSearch} className="header-search-form !hidden lg:!flex items-center">


### PR DESCRIPTION
### Description

Added a GitHub star counter and a clickable star button in the header.

### Changes Made

* Integrated GitHub REST API to fetch star count
* Displayed dynamic star count in navbar
* Added redirect button to repository

### Related Issue
<img width="1363" height="679" alt="Screenshot 2026-05-31 124240" src="https://github.com/user-attachments/assets/7e13b10c-95b7-4e39-bb16-ccfc401e3e9f" />

Fixes #19
