### PR TITLE
Design CUBO CGPA SVG logo assets

### DIFF
--- a/Applications/Tools/cubosapiens_cgpa/assets/favicon.svg
+++ b/Applications/Tools/cubosapiens_cgpa/assets/favicon.svg
@@ -1,0 +1,20 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">CUBO CGPA favicon</title>
+  <desc id="desc">Compact CGPA cube mark.</desc>
+  <defs>
+    <linearGradient id="bg" x1="10" y1="8" x2="54" y2="58" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5B7CFF"/>
+      <stop offset="0.55" stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#14B8A6"/>
+    </linearGradient>
+    <linearGradient id="ring" x1="17" y1="14" x2="50" y2="51" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FDE68A"/>
+      <stop offset="1" stop-color="#34D399"/>
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="52" height="52" rx="14" fill="url(#bg)"/>
+  <path d="M32 16L46 24V40L32 48L18 40V24L32 16Z" fill="#FFFFFF" fill-opacity="0.14" stroke="#FFFFFF" stroke-opacity="0.62" stroke-width="2"/>
+  <circle cx="32" cy="33" r="15" stroke="#FFFFFF" stroke-opacity="0.24" stroke-width="5"/>
+  <path d="M32 18A15 15 0 1 1 19.7 41.6" stroke="url(#ring)" stroke-width="5" stroke-linecap="round"/>
+  <path d="M22 36L28 30L33 34L42 24" stroke="#FDE68A" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/Applications/Tools/cubosapiens_cgpa/assets/logo.svg
+++ b/Applications/Tools/cubosapiens_cgpa/assets/logo.svg
@@ -1,0 +1,26 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">CUBO CGPA logo</title>
+  <desc id="desc">A geometric cube badge with an academic progress ring and CGPA lettering.</desc>
+  <defs>
+    <linearGradient id="cgpa-bg" x1="20" y1="14" x2="108" y2="116" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5B7CFF"/>
+      <stop offset="0.52" stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#14B8A6"/>
+    </linearGradient>
+    <linearGradient id="cgpa-ring" x1="30" y1="24" x2="100" y2="102" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FDE68A"/>
+      <stop offset="1" stop-color="#34D399"/>
+    </linearGradient>
+    <filter id="cgpa-shadow" x="10" y="12" width="108" height="108" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="10" stdDeviation="8" flood-color="#1E1B4B" flood-opacity="0.22"/>
+    </filter>
+  </defs>
+  <rect x="18" y="16" width="92" height="92" rx="24" fill="url(#cgpa-bg)" filter="url(#cgpa-shadow)"/>
+  <path d="M64 30L91 45.5V76.5L64 92L37 76.5V45.5L64 30Z" fill="#FFFFFF" fill-opacity="0.16" stroke="#FFFFFF" stroke-opacity="0.55" stroke-width="3" stroke-linejoin="round"/>
+  <path d="M64 30V61.5M91 45.5L64 61.5M37 45.5L64 61.5" stroke="#FFFFFF" stroke-opacity="0.45" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="64" cy="64" r="30" stroke="#FFFFFF" stroke-opacity="0.24" stroke-width="8"/>
+  <path d="M64 34A30 30 0 1 1 39.7 81.6" stroke="url(#cgpa-ring)" stroke-width="8" stroke-linecap="round"/>
+  <rect x="42" y="53" width="44" height="28" rx="8" fill="#0F172A" fill-opacity="0.72"/>
+  <path d="M50 69.5L57.5 61.5L64 67.5L74 56L82 65" stroke="#FDE68A" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="64" y="103" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="800" letter-spacing="1.2" fill="#FFFFFF">CGPA</text>
+</svg>

--- a/Applications/Tools/cubosapiens_cgpa/index.html
+++ b/Applications/Tools/cubosapiens_cgpa/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>CGPA Calculator</title>
+  <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -22,7 +23,7 @@
   <header>
     <div class="logo-wrap">
       <div class="logo-icon">
-        <img src="assets/logo.png" alt="Logo" />
+        <img src="assets/logo.svg" alt="CUBO CGPA logo" />
       </div>
       <span class="logo-name">CUBO<span>CGPA</span></span>
     </div>


### PR DESCRIPTION
## Summary
- Adds an original scalable SVG logo for CUBO CGPA
- Adds a compact SVG favicon with transparent background
- Updates the CGPA app header and favicon link to use the new SVG assets

## Validation
- Parsed both SVG files as XML locally
- Confirmed the app references resolve to the new assets

## GSSoC label fit
This is a tightly scoped design update for one application folder, matching level:beginner and 	ype:design from issue #83.

Closes #83