### PR TITLE
Improved Readme by adding  Table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,29 @@
 
 ---
 
+## Table of Contents
+
+- [GSSoC 2026 Badges](#gssoc-2026-badges)
+- [Connect With CuboSapiens](#connect-with-cubosapiens)
+- [Contributors](#contributors)
+- [What is CuboSapiens?](#what-is-cubosapiens)
+- [Features](#features)
+- [Tech Stack](#tech-stack)
+- [Browser Tools & Games Ecosystem](#browser-tools--games-ecosystem)
+- [Supported Project Categories](#supported-project-categories)
+- [Running the Project Locally](#running-the-project-locally)
+- [Running Standalone Applications](#running-standalone-applications)
+- [Contributing](#contributing)
+- [Contribution Guidelines](#contribution-guidelines)
+- [GSSoC 2026 Participation](#gssoc-2026-participation)
+- [Repository Goals](#repository-goals)
+- [Future Roadmap](#future-roadmap)
+- [Support the Project](#support-the-project)
+- [Maintainer](#maintainer)
+- [License](#license)
+
+---
+
 ## GSSoC 2026 Badges
 
 <p align="center">


### PR DESCRIPTION
Added a Table of Contents section near the top of the README (after the title/intro). The TOC should include links to all major sections using proper Markdown anchor links, and it should be easy to update whenever new sections are added.

closes #153 