### PR TITLE
feat: add personalized onboarding greeting with localStorage persistence

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -4149,3 +4149,179 @@ a {
     font-size: 2rem;
   }
 }
+
+/* =====================
+   ONBOARDING GREETING
+   ===================== */
+
+.hero-greeting {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-body);
+  font-size: clamp(20px, 3vw, 28px);
+  font-weight: 600;
+  color: var(--brand);
+  margin-bottom: 14px;
+}
+
+.hero-greeting-edit {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 10px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.hero-greeting-edit:hover {
+  border-color: var(--brand);
+  color: var(--brand);
+}
+
+.onboarding-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 999999;
+  background: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  animation: fadeIn 0.25s ease;
+  pointer-events: auto;
+}
+
+.onboarding-modal {
+  width: 100%;
+  max-width: 420px;
+  background: rgba(10, 10, 10, 0.98);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: var(--radius-lg);
+  padding: 36px 28px 28px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
+  animation: slideUp 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  position: relative;
+  z-index: 1;
+}
+
+.onboarding-title {
+  font-family: var(--font-heading);
+  font-size: 24px;
+  font-weight: 800;
+  color: var(--text-primary);
+  text-align: center;
+  margin-bottom: 10px;
+}
+
+.onboarding-subtitle {
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.55);
+  text-align: center;
+  margin-bottom: 22px;
+  line-height: 1.5;
+}
+
+.onboarding-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.onboarding-input {
+  width: 100%;
+  padding: 16px 18px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 2px solid rgba(255, 255, 255, 0.15);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 17px;
+  font-weight: 600;
+  font-family: var(--font-body);
+  outline: none;
+  transition: border-color 0.15s;
+  position: relative;
+  z-index: 2;
+}
+
+.onboarding-input:focus {
+  border-color: var(--brand);
+}
+
+.onboarding-input::placeholder {
+  color: var(--text-muted);
+}
+
+.onboarding-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.onboarding-submit {
+  flex: 1;
+  padding: 13px;
+  background: var(--brand);
+  color: #000;
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: 15px;
+  font-weight: 700;
+  font-family: var(--font-body);
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.onboarding-submit:hover {
+  opacity: 0.85;
+}
+
+.onboarding-cancel {
+  padding: 13px 18px;
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-md);
+  font-size: 15px;
+  font-family: var(--font-body);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.onboarding-cancel:hover {
+  border-color: rgba(255, 255, 255, 0.2);
+  color: var(--text-primary);
+}
+
+.onboarding-reset {
+  width: 100%;
+  margin-top: 14px;
+  padding: 10px;
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.35);
+  font-size: 12px;
+  font-family: var(--font-body);
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  transition: color 0.15s;
+}
+
+.onboarding-reset:hover {
+  color: #f87171;
+}
+
+.onboarding-submit,
+.onboarding-cancel,
+.onboarding-reset,
+.hero-greeting-edit {
+  cursor: pointer;
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -5,6 +5,7 @@ import AiAccessButton from "@/components/ui/AIAccessButton"
 // import ColorBends from "@/components/colorbends"
 // import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 // import AdUnit from "@/components/ui/AdUnit"
+import OnboardingGreeting from "@/components/ui/OnboardingGreeting"
 import type { Metadata } from "next"
 
 export const metadata: Metadata = {
@@ -74,6 +75,8 @@ export default async function HomePage() {
           Free · No signup · Works in browser
         </div> */}
 
+        <OnboardingGreeting />
+        
         <h1 className="hero-title">
           Everything you need.<br />
           <span className="hero-title-accent">All in One place.</span>

--- a/apps/web/src/components/ui/OnboardingGreeting.tsx
+++ b/apps/web/src/components/ui/OnboardingGreeting.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { createPortal } from "react-dom"
+import { useUserName } from "@/hooks/useUserName"
+import { getGreeting } from "@/lib/greeting"
+
+export default function OnboardingGreeting() {
+  const { name, setName, clearName, isLoaded } = useUserName()
+  const [showModal, setShowModal] = useState(false)
+  const [inputValue, setInputValue] = useState("")
+  const [isEditing, setIsEditing] = useState(false)
+  const [mounted, setMounted] = useState(false)
+
+  // Portals need to run client-side only, after mount
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  useEffect(() => {
+    if (isLoaded && !name) {
+      setShowModal(true)
+    }
+  }, [isLoaded, name])
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!inputValue.trim()) return
+    setName(inputValue)
+    setShowModal(false)
+    setIsEditing(false)
+    setInputValue("")
+  }
+
+  const handleEditClick = () => {
+    setInputValue(name ?? "")
+    setIsEditing(true)
+    setShowModal(true)
+  }
+
+  if (!isLoaded) return null
+
+  const modal = showModal ? (
+    <div className="onboarding-overlay" role="dialog" aria-modal="true">
+      <div className="onboarding-modal">
+        <h2 className="onboarding-title">
+          {isEditing ? "Edit your name" : "Welcome to CUBOSAPIENS"}
+        </h2>
+        <p className="onboarding-subtitle">
+          {isEditing
+            ? "Update the name we use to greet you."
+            : "What should we call you?"}
+        </p>
+        <form onSubmit={handleSubmit} className="onboarding-form">
+          <input
+            type="text"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            placeholder="Your name or nickname"
+            className="onboarding-input"
+            autoFocus
+            maxLength={30}
+          />
+          <div className="onboarding-actions">
+            <button type="submit" className="onboarding-submit">
+              {isEditing ? "Save" : "Continue"}
+            </button>
+            {isEditing && (
+              <button
+                type="button"
+                className="onboarding-cancel"
+                onClick={() => {
+                  setShowModal(false)
+                  setIsEditing(false)
+                }}
+              >
+                Cancel
+              </button>
+            )}
+          </div>
+        </form>
+        {isEditing && (
+          <button
+            type="button"
+            className="onboarding-reset"
+            onClick={() => {
+              clearName()
+              setShowModal(false)
+              setIsEditing(false)
+            }}
+          >
+            Forget my name
+          </button>
+        )}
+      </div>
+    </div>
+  ) : null
+
+  return (
+    <>
+      {name && (
+        <p className="hero-greeting">
+          {getGreeting()}, {name}
+          <button
+            type="button"
+            onClick={handleEditClick}
+            className="hero-greeting-edit"
+            aria-label="Edit your name"
+          >
+            <i className="fas fa-pen" />
+          </button>
+        </p>
+      )}
+
+      {mounted && modal && createPortal(modal, document.body)}
+    </>
+  )
+}

--- a/apps/web/src/hooks/useUserName.ts
+++ b/apps/web/src/hooks/useUserName.ts
@@ -1,0 +1,31 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+
+const STORAGE_KEY = "cubosapiens_user_name"
+
+export function useUserName() {
+  const [name, setNameState] = useState<string | null>(null)
+  const [isLoaded, setIsLoaded] = useState(false)
+
+  // Read from localStorage once, on mount (client-side only)
+  useEffect(() => {
+    const stored = window.localStorage.getItem(STORAGE_KEY)
+    setNameState(stored)
+    setIsLoaded(true)
+  }, [])
+
+  const setName = useCallback((newName: string) => {
+    const trimmed = newName.trim()
+    if (!trimmed) return
+    window.localStorage.setItem(STORAGE_KEY, trimmed)
+    setNameState(trimmed)
+  }, [])
+
+  const clearName = useCallback(() => {
+    window.localStorage.removeItem(STORAGE_KEY)
+    setNameState(null)
+  }, [])
+
+  return { name, setName, clearName, isLoaded }
+}

--- a/apps/web/src/lib/greeting.ts
+++ b/apps/web/src/lib/greeting.ts
@@ -1,0 +1,8 @@
+export function getGreeting(date: Date = new Date()): string {
+  const hour = date.getHours()
+
+  if (hour >= 5 && hour < 12) return "Good Morning"
+  if (hour >= 12 && hour < 17) return "Good Afternoon"
+  if (hour >= 17 && hour < 21) return "Good Evening"
+  return "Welcome Back" // night hours, 9pm–5am
+}


### PR DESCRIPTION
Closes #16 

## Summary
Implements a personalized onboarding experience for first-time visitors as described in the issue.

## Changes
- Added `useUserName` hook for localStorage-backed name persistence
- Added `getGreeting()` utility for time-of-day based greeting text (Morning/Afternoon/Evening/Welcome Back)
- Added `OnboardingGreeting` client component:
  - Shows a welcome modal on first visit prompting for a name
  - Displays a dynamic greeting above the hero title on return visits
  - Includes an edit (pencil icon) flow to update the stored name — reopens the modal pre-filled with the current name
  - Includes a "Forget my name" option that clears localStorage entirely and re-triggers the first-time welcome flow (blank input, "Welcome to CUBOSAPIENS" copy) rather than just closing the modal
  - Currently, since name is the only value persisted, Edit and Forget produce a similar end state (both let you set a new name) but they're built as functionally distinct actions: Edit *updates* the existing value, Forget *deletes* it and resets onboarding state. This keeps the door open for storing additional preferences later, where "Forget" would need to wipe more than just the name
  - Modal is rendered via a React Portal into `document.body` to avoid z-index/stacking-context conflicts with the hero section
- Added matching styles in `globals.css` (modal, greeting text, buttons) consistent with the existing dark/green theme

## Testing done
- First visit → modal appears, name entry works
- Returning visit → greeting shows automatically with correct time-of-day text
- Edit flow → pencil icon opens pre-filled modal, save updates greeting instantly
- Forget flow → clears storage, re-triggers welcome modal
- Verified no console errors across the flow
- Verified modal/buttons are clickable and not obscured by other page elements

## Screenshots
<img width="1512" height="794" alt="image" src="https://github.com/user-attachments/assets/e5d5239e-b39e-4699-96e8-82100f77fc27" />
<img width="1512" height="794" alt="image" src="https://github.com/user-attachments/assets/a2931679-4941-47a1-bade-474c264d9a5a" />
<img width="1512" height="794" alt="image" src="https://github.com/user-attachments/assets/75f8b7e5-0c2e-4716-bb6f-e8657f9ce143" />
<img width="1512" height="794" alt="image" src="https://github.com/user-attachments/assets/afd06ccd-2a58-461b-9417-d8c5be65e4c7" />
<img width="1512" height="794" alt="image" src="https://github.com/user-attachments/assets/ee3cd38e-fdfc-488b-9a5b-1f7d7ac912a6" />
<img width="1512" height="794" alt="image" src="https://github.com/user-attachments/assets/6a616e2e-f7ca-46bf-8c7b-bc8048a7b6c0" />
