### PR TITLE
docs: format directory tree as a code block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ The platform focuses on:
 
 # Browser Tools & Games Ecosystem
 
+```text
 Applications/
  ├── Tools/
  ├── Games/

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The platform focuses on:
 Applications/
  ├── Tools/
  ├── Games/
-
+```
 Example:
 
 Applications/Games/cubosapiens-games-snake  


### PR DESCRIPTION
## Description
Formatted the directory structure in the "Browser Tools & Games Ecosystem" section of the `README.md` into a code block.

## Why this is needed
Standard Markdown ignores multiple spaces and single line breaks, causing ASCII directory trees to render as misaligned, messy paragraphs on GitHub. Wrapping it in a `text` code block preserves the exact spacing, line breaks, and monospace font, ensuring the folder tree renders clearly and correctly for readers.

## Changes Made
- Wrapped the `Applications/` directory tree and examples inside a ` ```text ` block.