### PR TITLE
Fix: AI navigation bar error

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -74,12 +74,15 @@ export const metadata: Metadata = {
 export const viewport = {
   themeColor: "#000000",
 }
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode
 })
 {
+  const aiTools = await fetchTools({ category: "ai" })
+  const hasLiveAi = aiTools.length > 0
+
   return (
     <html lang="en" suppressHydrationWarning className={cn("font-sans", geist.variable)}>
      <head>
@@ -89,7 +92,7 @@ export default function RootLayout({
 </head>
       <body className={`${alfaSlabOne.variable} ${syne.variable} ${dmSans.variable}`}>
         <TrackVisit />
-        <Header hasLiveAi={false} />
+        <Header hasLiveAi={hasLiveAi} />
         <main>{children}</main>
         <Footer />
         <PWAInstallPrompt />


### PR DESCRIPTION
Hi! The root cause appears to be in `apps/web/src/app/layout.tsx` where it hardcodes `<Header hasLiveAi={false} />`. That boolean value is used everywhere and hat decides whether the navbar `"AI"` link is a real `<Link>` or a `"Coming Soon"` gate button. It doesn't actually check the number of tools tagged with `AI`.

I propose the following:

```
const aiTools = await fetchTools({ category: "ai" })
const hasLiveAi = aiTools.length > 0
...
<Header hasLiveAi={hasLiveAi} />
```

Basically, to check if tools with the category exist and determine the flag as necessary.
`fetchTools()` already existed as a function before, was not used and I am just calling it non-blocking-ly.

I would recommend someone to implement similar logic for games and tools as well. Preferably not for the blog section.

https://github.com/user-attachments/assets/8c605d05-b37a-49a0-8462-31ca866324b9