### PR TITLE
chore: add issue templates in .github (.github/ISSUE_TEMPLATE)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,68 @@
+---
+name: Bug Report 🐛
+about: Report a bug to help us improve Cubosapiens_World-Tools
+title: "[BUG] <short description of the bug>"
+labels: bug
+assignees: ''
+---
+
+## 🐛 Bug Description
+
+A clear and concise description of what the bug is.
+
+---
+
+## 🔁 Steps to Reproduce
+
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '...'
+3. Upload document '...'
+4. Scroll down to '...'
+5. See error
+
+---
+
+## ✅ Expected Behavior
+
+A clear and concise description of what you expected to happen.
+
+---
+
+## ❌ Actual Behavior
+
+A clear and concise description of what actually happened.
+Include any error messages or unexpected outputs you observed.
+
+---
+
+## 📸 Screenshots
+
+If applicable, add screenshots to help explain your problem.
+
+> Tip: On Mac use Cmd+Shift+4 to capture a selected area.
+> On Windows use Win+Shift+S to capture a selected area.
+
+---
+
+
+## 📄 Document Details (if applicable)
+
+- **Document Type:** (e.g. PDF, PNG, JPG)
+- **Document Size:** (e.g. 2MB)
+- **Was OCR involved?** (Yes / No)
+
+---
+
+## 🔍 Possible Cause (optional)
+
+If you have an idea of what might be causing the bug, mention it here.
+
+---
+
+## 📋 Additional Context
+
+Add any other context about the problem here.
+Any logs, error traces, or console output can be pasted below.
+

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest an idea or new capability for Cubosapiens_World-Tools
+title: '[FEATURE]: '
+labels: ['enhancement']
+assignees: ''
+---
+
+## 💡 Proposed Solution
+A clear and concise description of the new feature or modification you are proposing. Explain the implementation details or technical details if any.
+
+## 👤 User Context & Problem Statement
+Is your feature request related to a problem? Please describe. 
+*E.g., "I'm always frustrated when..."*
+
+## 🔄 Alternatives Considered
+A clear and concise description of any alternative solutions or features you've considered, and why they were not chosen.
+
+## 🎨 Visual Mockups / Screenshots (if applicable)
+If applicable, add design mockups, wireframes, or reference UI/UX layouts to help visualize the requested feature.
+
+## 📌 Additional Context
+Add any other context, user stories, or technical guidance about the feature request here.


### PR DESCRIPTION
**Summary**
Added GitHub issue templates to improve consistency in issue reporting.

**Related Issue**
closes #403 

**Changes**
- Added issue template files under `.github/`
- Included templates for common issue types
- Improved issue reporting workflow for contributors

**Why this needed**
-Contributors know exactly what information to provide.
-Maintainers can triage issues faster.
-Bug reports, feature requests, and documentation changes stay more organized.
-New contributors have an easier time opening the right kind of issue.

 **Notes**
This is a maintenance/workflow change and does not affect application code.