### PR TITLE
docs: add missing Repository Badges entry in table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
 - [Future Roadmap](#future-roadmap)
 - [Support the Project](#support-the-project)
 - [Maintainer](#maintainer)
+- [Repository Badges](#repository-badges)
 - [License](#license)
 
 ---


### PR DESCRIPTION
PR Description: Fixed the Table of Contents in README.md — the "Repository Badges" section existed in the document but was missing from the TOC list. Added the missing entry.

Issue: closes #None (just a documentation quick fix )